### PR TITLE
replaced deprecated apt-key usage

### DIFF
--- a/templates/pages/download/linux/debian.html
+++ b/templates/pages/download/linux/debian.html
@@ -49,7 +49,8 @@ To use the apt repository, follow these steps:
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # Import the repository signing key:
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.asc
+      
 
 # Update the package lists:
 sudo apt-get update


### PR DESCRIPTION
apt-key was deprecated some Debian versions ago. This change follows the first suggestion for the DEPRECATION section of apt-key manpages.